### PR TITLE
Do not always add _0 when having prefix and suffix

### DIFF
--- a/lib/fluent/plugin/out_file_alternative.rb
+++ b/lib/fluent/plugin/out_file_alternative.rb
@@ -88,11 +88,14 @@ class Fluent::FileAlternativeOutput < Fluent::TimeSlicedOutput
              end
     if @path_prefix and @path_suffix
       if @compress
-        i = 0
-        begin
-          path = "#{@path_prefix}#{chunk_key}_#{i}#{@path_suffix}#{suffix}"
-          i += 1
-        end while File.exist?(path)
+        path = "#{@path_prefix}#{chunk_key}#{@path_suffix}#{suffix}"
+        if File.exist?(path)
+          i = 0
+          begin
+            path = "#{@path_prefix}#{chunk_key}_#{i}#{@path_suffix}#{suffix}"
+            i += 1
+          end while File.exist?(path)
+        end
         path
       else
         "#{@path_prefix}#{chunk_key}#{@path_suffix}#{suffix}"


### PR DESCRIPTION
I think always adding a _0 here without first checking to see if the file exists is unintended behavior.
