### PR TITLE
Add config descriptions

### DIFF
--- a/lib/fluent/plugin/out_file_alternative.rb
+++ b/lib/fluent/plugin/out_file_alternative.rb
@@ -15,9 +15,15 @@ class Fluent::FileAlternativeOutput < Fluent::TimeSlicedOutput
 
   config_set_default :time_slice_format, '%Y%m%d' # %Y%m%d%H
 
-  config_param :path, :string  # /path/pattern/to/hdfs/file can use %Y %m %d %H %M %S
+  config_param :path, :string,
+               :desc => <<-DESC
+The Path of the file.
+/path/pattern/to/hdfs/file can use %Y %m %d %H %M %S
+DESC
 
-  config_param :compress, :default => nil do |val|
+  config_param :compress,
+               :desc => "Supported format: #{SUPPORTED_COMPRESS.keys}",
+               :default => nil do |val|
     c = SUPPORTED_COMPRESS[val.to_sym]
     unless c
       raise ConfigError, "Unsupported compression algorithm '#{compress}'"
@@ -25,11 +31,14 @@ class Fluent::FileAlternativeOutput < Fluent::TimeSlicedOutput
     c
   end
 
-  config_param :symlink_path, :string, :default => nil
+  config_param :symlink_path, :string, :default => nil,
+               :desc => "Create symlink to temporary buffered file when buffer_type is file."
 
-  config_param :dir_mode, :string, :default => '0777'
+  config_param :dir_mode, :string, :default => '0777',
+               :desc =>  "The mode of the directory."
 
-  config_param :set_dir_mode, :bool, :default => true
+  config_param :set_dir_mode, :bool, :default => true,
+               :desc => "Set the mode of the directory."
 
   include Fluent::Mixin::PlainTextFormatter
 


### PR DESCRIPTION
Descriptions are shown like this:

```log
2016-01-06 15:31:52 +0900 [info]: Show config for output:file_alternative
2016-01-06 15:31:52 +0900 [info]: 
log_level: string: <nil> # Allows the user to set different levels of logging for each plugin.
buffer_type: string: <"memory">
flush_interval: time: <60>
try_flush_interval: float: <1>
disable_retry_limit: bool: <false>
retry_limit: integer: <17>
retry_wait: time: <1.0>
max_retry_wait: time: <nil>
num_threads: integer: <1>
queued_chunk_flush_interval: time: <1>
time_slice_format: string: <"%Y%m%d">
time_slice_wait: time: <600>
timezone: string: <nil>
path: string: <nil> # The Path of the file.
/path/pattern/to/hdfs/file can use %Y %m %d %H %M %S

compress: : <nil> # Supported format: [:gz, :gzip]
symlink_path: string: <nil> # Create symlink to temporary buffered file when buffer_type is file.
dir_mode: string: <"0777"> # The mode of the directory.
set_dir_mode: bool: <true> # Set the mode of the directory.
```