### PR TITLE
[WIP][expermental] Windows support

### DIFF
--- a/lib/fluent/plugin/out_file_alternative.rb
+++ b/lib/fluent/plugin/out_file_alternative.rb
@@ -167,7 +167,7 @@ class Fluent::FileAlternativeOutput < Fluent::TimeSlicedOutput
 
       Pathname.new(path).descend {|p|
         FileUtils.mkdir_p( File.dirname(p)) unless File.directory?(p)
-        if @set_dir_mode
+        if @set_dir_mode && !windows?
           FileUtils.chmod @dir_mode.to_i(8), File.dirname(p) unless File.directory?(p)
         end
       }

--- a/lib/fluent/plugin/out_file_alternative.rb
+++ b/lib/fluent/plugin/out_file_alternative.rb
@@ -66,6 +66,12 @@ class Fluent::FileAlternativeOutput < Fluent::TimeSlicedOutput
       conf['buffer_path'] ||= conf['path'].gsub('%Y','yyyy').gsub('%m','mm').gsub('%d','dd').gsub('%H','HH').gsub('%M','MM').gsub('%S','SS')
     end
 
+    if windows?
+      if @set_dir_mode
+        log.info "File permission changing feature is not supported on Windows."
+      end
+    end
+
     super
 
     validate_path

--- a/lib/fluent/plugin/out_file_alternative.rb
+++ b/lib/fluent/plugin/out_file_alternative.rb
@@ -85,10 +85,7 @@ class Fluent::FileAlternativeOutput < Fluent::TimeSlicedOutput
     end
 
     if @symlink_path
-      unless @symlink_path.gsub("\\","/") =~ /^[a-zA-z]:\//
-        raise Fluent::ConfigError, "Symlink path on filesystem in Windows MUST starts with '[a-zA-z]:\', but '#{@symlink_path}'"
-      end
-      @buffer.symlink_path = @symlink_path
+      raise Fluent::ConfigError, "Symlink on Windows is not supported."
     end
   end
 

--- a/lib/fluent/plugin/out_file_alternative.rb
+++ b/lib/fluent/plugin/out_file_alternative.rb
@@ -80,12 +80,12 @@ class Fluent::FileAlternativeOutput < Fluent::TimeSlicedOutput
   end
 
   def validate_path_for_windows
-    unless @path.index(/^[a-zA-z]:\\/) == 0
+    unless @path.gsub("\\","/") =~ /^[a-zA-z]:\//
       raise Fluent::ConfigError, "Path on filesystem in Windows MUST starts with '[a-zA-z]:\', but '#{@path}'"
     end
 
     if @symlink_path
-      unless @symlink_path.index((/^[a-zA-z]:\\/)) == 0
+      unless @symlink_path.gsub("\\","/") =~ /^[a-zA-z]:\//
         raise Fluent::ConfigError, "Symlink path on filesystem in Windows MUST starts with '[a-zA-z]:\', but '#{@symlink_path}'"
       end
       @buffer.symlink_path = @symlink_path

--- a/lib/fluent/plugin/out_file_alternative.rb
+++ b/lib/fluent/plugin/out_file_alternative.rb
@@ -152,7 +152,7 @@ class Fluent::FileAlternativeOutput < Fluent::TimeSlicedOutput
           chunk.write_to(f)
         }
       else
-        File.open(path, "a") {|f|
+        File.open(path, "ab") {|f|
           chunk.write_to(f)
         }
       end

--- a/lib/fluent/plugin/out_file_alternative.rb
+++ b/lib/fluent/plugin/out_file_alternative.rb
@@ -86,7 +86,7 @@ class Fluent::FileAlternativeOutput < Fluent::TimeSlicedOutput
   end
 
   def validate_path_for_windows
-    unless @path.gsub("\\","/") =~ /^[a-zA-z]:\//
+    unless @path.gsub("\\","/") =~ /\A[a-zA-z]:\//
       raise Fluent::ConfigError, "Path on filesystem in Windows MUST starts with '[a-zA-z]:\', but '#{@path}'"
     end
 

--- a/lib/fluent/plugin/out_file_alternative.rb
+++ b/lib/fluent/plugin/out_file_alternative.rb
@@ -1,4 +1,5 @@
 require 'fluent/mixin/plaintextformatter'
+require 'fluent/plugin/windows_util'
 
 class Fluent::FileAlternativeOutput < Fluent::TimeSlicedOutput
   Fluent::Plugin.register_output('file_alternative', self)
@@ -32,6 +33,7 @@ class Fluent::FileAlternativeOutput < Fluent::TimeSlicedOutput
   config_param :set_dir_mode, :bool, :default => true
 
   include Fluent::Mixin::PlainTextFormatter
+  include Fluent::FileAlternative::WindowsUtil
 
   def initialize
     super
@@ -106,10 +108,6 @@ class Fluent::FileAlternativeOutput < Fluent::TimeSlicedOutput
       end
       @buffer.symlink_path = @symlink_path
     end
-  end
-
-  def windows?
-    RUBY_PLATFORM =~ /mswin(?!ce)|mingw|cygwin|bccwin/
   end
 
   def start

--- a/lib/fluent/plugin/windows_util.rb
+++ b/lib/fluent/plugin/windows_util.rb
@@ -1,0 +1,9 @@
+module Fluent
+  module FileAlternative
+    module WindowsUtil
+      def windows?
+        RUBY_PLATFORM =~ /mswin(?!ce)|mingw|cygwin|bccwin/
+      end
+    end
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,6 +23,7 @@ unless ENV.has_key?('VERBOSE')
 end
 
 require 'fluent/plugin/out_file_alternative'
+require 'fluent/plugin/windows_util'
 
 class Test::Unit::TestCase
 end

--- a/test/plugin/test_out_file_alternative.rb
+++ b/test/plugin/test_out_file_alternative.rb
@@ -1,6 +1,8 @@
 require 'helper'
 
 class FileAlternativeOutputTest < Test::Unit::TestCase
+  include Fluent::FileAlternative::WindowsUtil
+
   TMP_DIR = File.dirname(__FILE__) + "/../tmp"
 
   CONFIG = %[
@@ -9,10 +11,6 @@ class FileAlternativeOutputTest < Test::Unit::TestCase
   ]
 
   SYMLINK_PATH = File.expand_path("#{TMP_DIR}/current")
-
-  def windows?
-    RUBY_PLATFORM =~ /mswin(?!ce)|mingw|cygwin|bccwin/
-  end
 
   def setup
     Fluent::Test.setup

--- a/test/plugin/test_out_file_alternative.rb
+++ b/test/plugin/test_out_file_alternative.rb
@@ -153,7 +153,7 @@ class FileAlternativeOutputTest < Test::Unit::TestCase
   end
 
   def test_write_with_symlink
-    omit "Windows does not support synlink" if windows?
+    omit "Windows does not support symlink" if windows?
     conf = CONFIG + %[
       symlink_path #{SYMLINK_PATH}
     ]
@@ -179,7 +179,7 @@ class FileAlternativeOutputTest < Test::Unit::TestCase
   end
 
   def test_disable_chmod
-    omit "NTFS does not support UNIX-like permissons." if windows?
+    omit "NTFS does not support UNIX-like permissions." if windows?
     d = create_driver %{
       path #{TMP_DIR}/path_to_test/%Y/%m/%d/accesslog.%Y-%m-%d-%H-%M-%S
       dir_mode 0700

--- a/test/plugin/test_out_file_alternative.rb
+++ b/test/plugin/test_out_file_alternative.rb
@@ -179,6 +179,7 @@ class FileAlternativeOutputTest < Test::Unit::TestCase
   end
 
   def test_disable_chmod
+    omit "NTFS does not support UNIX-like permissons." if windows?
     d = create_driver %{
       path #{TMP_DIR}/path_to_test/%Y/%m/%d/accesslog.%Y-%m-%d-%H-%M-%S
       dir_mode 0700

--- a/test/plugin/test_out_file_alternative.rb
+++ b/test/plugin/test_out_file_alternative.rb
@@ -10,6 +10,10 @@ class FileAlternativeOutputTest < Test::Unit::TestCase
 
   SYMLINK_PATH = File.expand_path("#{TMP_DIR}/current")
 
+  def windows?
+    RUBY_PLATFORM =~ /mswin(?!ce)|mingw|cygwin|bccwin/
+  end
+
   def setup
     Fluent::Test.setup
     FileUtils.rm_rf(TMP_DIR)
@@ -149,6 +153,7 @@ class FileAlternativeOutputTest < Test::Unit::TestCase
   end
 
   def test_write_with_symlink
+    omit "Windows does not support synlink" if windows?
     conf = CONFIG + %[
       symlink_path #{SYMLINK_PATH}
     ]

--- a/test/plugin/test_out_file_alternative.rb
+++ b/test/plugin/test_out_file_alternative.rb
@@ -145,9 +145,13 @@ class FileAlternativeOutputTest < Test::Unit::TestCase
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
     d4.emit({"server" => "www01", "level" => "warn", "log" => "Exception\n"}, time)
     path = d4.run
-    assert_equal '40700', File.stat(File.dirname(File.dirname(File.dirname(path[0])))).mode.to_s(8)
-    assert_equal '40700', File.stat(File.dirname(File.dirname(path[0]))).mode.to_s(8)
-    assert_equal '40700', File.stat(File.dirname(path[0])).mode.to_s(8)
+    if windows?
+      omit "NTFS does not support UNIX-like permissions."
+    else
+      assert_equal '40700', File.stat(File.dirname(File.dirname(File.dirname(path[0])))).mode.to_s(8)
+      assert_equal '40700', File.stat(File.dirname(File.dirname(path[0]))).mode.to_s(8)
+      assert_equal '40700', File.stat(File.dirname(path[0])).mode.to_s(8)
+    end
     assert_equal "#{TMP_DIR}/path_to_test/2011/01/02/accesslog.2011-01-02-13-14-15", path[0]
 
   end


### PR DESCRIPTION
This is work in progress and experimental PR.

Feel free to reject this PR. 
I does not have a enough confidence to ship Windows compatibility change.
I'm wondering this plugin should support Windows or not.
### Limitations for Windows NTFS
- NTFS does not support symlink
- NTFS does not support UNIX-like permissions mechanism
  - File.chmod is a no-op on Windows
### Current status

This PR's file_alternative plugin is already woking well on Windows, but some tests are failing like this:

``` log
Loaded suite C:/Ruby22/lib/ruby/2.2.0/rake/rake_test_loader
Started
FileAlternativeOutputTest: 
  test_configure:                   .: (0.078000)
  test_disable_chmod:                   O
===============================================================================
NTFS does not support UNIX-like permissions. [test_disable_chmod(FileAlternativeOutputTest)]
C:/Users/hhatake/Documents/GitHub/fluent-plugin-file-alternative/test/plugin/test_out_file_alternative.rb:184:in `test_disable_chmod'
===============================================================================
: (0.000000)
  test_format:                      .: (2.516605)
  test_write:                       F
===============================================================================
Failure: test_write(FileAlternativeOutputTest)
C:/Users/hhatake/Documents/GitHub/fluent-plugin-file-alternative/test/plugin/test_out_file_alternative.rb:115:in `test_write'
     112:     d2.expect_format %[abc-xyz-123\n]
     113:     d2.expect_format %[123-456-789\n]
     114:     path = d2.run
  => 115:     assert_equal "#{TMP_DIR}/accesslog.2011-01-02-13-14-15", path[0]
     116: 
     117:     d3 = create_driver %[
     118:       path #{TMP_DIR}/accesslog.%Y-%m-%d-%H-%M-%S
<"C:/Users/hhatake/Documents/GitHub/fluent-plugin-file-alternative/test/plugin/../tmp/accesslog.2011-01-02-13-14-15"> expected but was
<"C:/Users/hhatake/Documents/GitHub/fluent-plugin-file-alternative/test/plugin/../tmp/accesslog.2011-01-02-22-14-15">

diff:
? C:/Users/hhatake/Documents/GitHub/fluent-plugin-file-alternative/test/plugin/../tmp/accesslog.2011-01-02-13-14-15
?                                                                                                          22      
===============================================================================
: (0.670801)
  test_write_with_symlink:              O
===============================================================================
Windows does not support symlink [test_write_with_symlink(FileAlternativeOutputTest)]
C:/Users/hhatake/Documents/GitHub/fluent-plugin-file-alternative/test/plugin/test_out_file_alternative.rb:158:in `test_write_with_symlink'
===============================================================================
: (0.000000)

Finished in 3.265406 seconds.
------
5 tests, 11 assertions, 1 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
66.6667% passed
------
1.53 tests/s, 3.37 assertions/s
```
